### PR TITLE
Fix for redating related bugs

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -90,10 +90,6 @@ func addCommand() cli.Command {
 				return err
 			}
 			save(list, fileName)
-			if err != nil {
-				fmt.Println(err)
-				return err
-			}
 			return nil
 		},
 	}
@@ -135,10 +131,6 @@ func switchStatusCommand() cli.Command {
 			number := c.Int("number")
 			switchTodoStatus(listByFile, listByPeriod, number)
 			save(listByFile, fileName)
-			if err != nil {
-				fmt.Println(err)
-				return err
-			}
 			return nil
 		},
 	}
@@ -178,12 +170,12 @@ func deleteCommand() cli.Command {
 			}
 
 			number := c.Int("number")
-			listByFile = deleteTodo(listByFile, listByPeriod, number)
-			save(listByFile, fileName)
+			listByFile, err = deleteTodo(listByFile, listByPeriod, number - 1)
 			if err != nil {
 				fmt.Println(err)
 				return err
 			}
+			save(listByFile, fileName)
 			return nil
 		},
 	}


### PR DESCRIPTION
This commit provides fixes for the following issues:
 - Calling the redating command with a number that does not match a todo
   in the specified time range results in an empty todofile.
 - The code for determining the todo in the specified time range
   contained a bug. (Part of the changeDateOfTodo function)
 - The code for mapping the todo from the specified time range to the
   global todolist contained a bug. (Part of the deleteTodo function)